### PR TITLE
Modified copy_ros_msg.cpp to replace traditional for loop with range base for loops

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ qtcreator-*
 
 _build
 _autosummary
+
+# VSCode Devcontainer
+.devcontainer

--- a/moveit_py/src/moveit/moveit_py_utils/src/copy_ros_msg.cpp
+++ b/moveit_py/src/moveit/moveit_py_utils/src/copy_ros_msg.cpp
@@ -122,10 +122,9 @@ shape_msgs::msg::SolidPrimitive SolidPrimitiveToCpp(const py::object& primitive)
   // recreate instance in C++ using python object data
   shape_msgs::msg::SolidPrimitive primitive_cpp;
   primitive_cpp.type = primitive.attr("type").cast<int>();
-  int num_dimensions = primitive.attr("dimensions").attr("__len__")().cast<int>();
-  for (int j = 0; j < num_dimensions; j++)
+  for (auto& dimension : primitive.attr("dimensions"))
   {
-    primitive_cpp.dimensions.push_back(primitive.attr("dimensions").attr("__getitem__")(j).cast<double>());
+    primitive_cpp.dimensions.push_back(py::reinterpret_borrow<py::object>(dimension).cast<double>());
   }
 
   return primitive_cpp;
@@ -147,14 +146,14 @@ shape_msgs::msg::Mesh MeshToCpp(const py::object& mesh)
   // recreate instance in C++ using python object data
   shape_msgs::msg::Mesh mesh_cpp;
   mesh_cpp.vertices.resize(mesh.attr("vertices").attr("__len__")().cast<int>());
-  for (int j = 0; j < mesh.attr("vertices").attr("__len__")().cast<int>(); j++)
+  for (const auto& vertex : mesh.attr("vertices"))
   {
-    mesh_cpp.vertices.push_back(PointToCpp(mesh.attr("vertices").attr("__getitem__")(j)));
+    mesh_cpp.vertices.push_back(PointToCpp(py::reinterpret_borrow<py::object>(vertex)));
   }
   mesh_cpp.triangles.resize(mesh.attr("triangles").attr("__len__")().cast<int>());
-  for (int j = 0; j < mesh.attr("triangles").attr("__len__")().cast<int>(); j++)
+  for (const auto& triangle : mesh.attr("triangles"))
   {
-    mesh_cpp.triangles.push_back(MeshTriangleToCpp(mesh.attr("triangles").attr("__getitem__")(j)));
+    mesh_cpp.triangles.push_back(MeshTriangleToCpp(py::reinterpret_borrow<py::object>(triangle)));
   }
 
   return mesh_cpp;
@@ -166,29 +165,27 @@ moveit_msgs::msg::BoundingVolume BoundingVolumeToCpp(const py::object& bounding_
   moveit_msgs::msg::BoundingVolume bounding_volume_cpp;
 
   // primitives
-  for (int j = 0; j < bounding_volume.attr("primitives").attr("__len__")().cast<int>(); j++)
+  for (const auto& primitive : bounding_volume.attr("primitives"))
   {
-    bounding_volume_cpp.primitives.push_back(
-        SolidPrimitiveToCpp(bounding_volume.attr("primitives").attr("__getitem__")(j)));
+    bounding_volume_cpp.primitives.push_back(SolidPrimitiveToCpp(py::reinterpret_borrow<py::object>(primitive)));
   }
 
   // primitive poses
-  for (int j = 0; j < bounding_volume.attr("primitive_poses").attr("__len__")().cast<int>(); j++)
+  for (const auto& primitive_pose : bounding_volume.attr("primitive_poses"))
   {
-    bounding_volume_cpp.primitive_poses.push_back(
-        PoseToCpp(bounding_volume.attr("primitive_poses").attr("__getitem__")(j)));
+    bounding_volume_cpp.primitive_poses.push_back(PoseToCpp(py::reinterpret_borrow<py::object>(primitive_pose)));
   }
 
   // meshes
-  for (int j = 0; j < bounding_volume.attr("meshes").attr("__len__")().cast<int>(); j++)
+  for (const auto& mesh : bounding_volume.attr("meshes"))
   {
-    bounding_volume_cpp.meshes.push_back(MeshToCpp(bounding_volume.attr("meshes").attr("__getitem__")(j)));
+    bounding_volume_cpp.meshes.push_back(MeshToCpp(py::reinterpret_borrow<py::object>(mesh)));
   }
 
   // mesh poses
-  for (int j = 0; j < bounding_volume.attr("mesh_poses").attr("__len__")().cast<int>(); j++)
+  for (const auto& mesh_poses : bounding_volume.attr("mesh_poses"))
   {
-    bounding_volume_cpp.mesh_poses.push_back(PoseToCpp(bounding_volume.attr("mesh_poses").attr("__getitem__")(j)));
+    bounding_volume_cpp.mesh_poses.push_back(PoseToCpp(py::reinterpret_borrow<py::object>(mesh_poses)));
   }
 
   return bounding_volume_cpp;
@@ -275,39 +272,31 @@ moveit_msgs::msg::CollisionObject CollisionObjectToCpp(const py::object& collisi
   collision_object_cpp.type.db = collision_object.attr("type").attr("db").cast<std::string>();
 
   // iterate through python list creating C++ vector of primitives
-  int num_primitives = collision_object.attr("primitives").attr("__len__")().cast<int>();
-  for (int i = 0; i < num_primitives; i++)
+  for (const auto& primitive : collision_object.attr("primitives"))
   {
-    py::object primitive = collision_object.attr("primitives").attr("__getitem__")(i);
-    auto primitive_cpp = SolidPrimitiveToCpp(primitive);
+    auto primitive_cpp = SolidPrimitiveToCpp(py::reinterpret_borrow<py::object>(primitive));
     collision_object_cpp.primitives.push_back(primitive_cpp);
   }
 
   // iterate through python list creating C++ vector of primitive poses
-  int num_primitives_poses = collision_object.attr("primitive_poses").attr("__len__")().cast<int>();
-  for (int i = 0; i < num_primitives_poses; i++)
+  for (const auto& primitive_pose : collision_object.attr("primitive_poses"))
   {
-    py::object primitive_pose = collision_object.attr("primitive_poses").attr("__getitem__")(i);
-    auto primitive_pose_cpp = PoseToCpp(primitive_pose);
+    auto primitive_pose_cpp = PoseToCpp(py::reinterpret_borrow<py::object>(primitive_pose));
     collision_object_cpp.primitive_poses.push_back(primitive_pose_cpp);
   }
 
   // iterate through python list creating C++ vector of meshes
-  int num_meshes = collision_object.attr("meshes").attr("__len__")().cast<int>();
-  for (int i = 0; i < num_meshes; i++)
+  for (const auto& mesh : collision_object.attr("meshes"))
   {
     // TODO (peterdavidfagan):  implement mesh conversion
-    py::object mesh = collision_object.attr("meshes").attr("__getitem__")(i);
-    auto mesh_cpp = MeshToCpp(mesh);
+    auto mesh_cpp = MeshToCpp(py::reinterpret_borrow<py::object>(mesh));
     collision_object_cpp.meshes.push_back(mesh_cpp);
   }
 
   // iterate through python list creating C++ vector of mesh poses
-  int num_mesh_poses = collision_object.attr("mesh_poses").attr("__len__")().cast<int>();
-  for (int i = 0; i < num_mesh_poses; i++)
+  for (const auto& mesh_pose : collision_object.attr("mesh_poses"))
   {
-    py::object mesh_pose = collision_object.attr("mesh_poses").attr("__getitem__")(i);
-    auto mesh_pose_cpp = PoseToCpp(mesh_pose);
+    auto mesh_pose_cpp = PoseToCpp(py::reinterpret_borrow<py::object>(mesh_pose));
     collision_object_cpp.mesh_poses.push_back(mesh_pose_cpp);
   }
 
@@ -323,38 +312,34 @@ moveit_msgs::msg::Constraints ConstraintsToCpp(const py::object& constraints)
   moveit_msgs::msg::Constraints constraints_cpp;
 
   // iterate through python list creating C++ vector of joint constraints
-  int num_joint_constraints = constraints.attr("joint_constraints").attr("__len__")().cast<int>();
-  for (int i = 0; i < num_joint_constraints; i++)
+  for (const auto& joint_constraint : constraints.attr("joint_constraints"))
   {
-    py::object joint_constraint = constraints.attr("__getitem__")(i);
-    auto joint_constraint_cpp = JointConstraintToCpp(joint_constraint);
+    auto joint_constraint_cpp = JointConstraintToCpp(py::reinterpret_borrow<py::object>(joint_constraint));
     constraints_cpp.joint_constraints.push_back(joint_constraint_cpp);
   }
 
   // iterate through python list creating C++ vector of position constraints
   int num_position_constraints = constraints.attr("position_constraints").attr("__len__")().cast<int>();
-  for (int i = 0; i < num_position_constraints; i++)
+  for (const auto& position_constraint : constraints.attr("position_constraints"))
   {
-    py::object position_constraint = constraints.attr("__getitem__")(i);
-    auto position_constraint_cpp = PositionConstraintToCpp(position_constraint);
+    auto position_constraint_cpp = PositionConstraintToCpp(py::reinterpret_borrow<py::object>(position_constraint));
     constraints_cpp.position_constraints.push_back(position_constraint_cpp);
   }
 
   // iterate through python list creating C++ vector of orientation constraints
   int num_orientation_constraints = constraints.attr("orientation_constraints").attr("__len__")().cast<int>();
-  for (int i = 0; i < num_orientation_constraints; i++)
+  for (const auto& orientation_constraint : constraints.attr("orientation_constraints"))
   {
-    py::object orientation_constraint = constraints.attr("orientation_constraints").attr("__getitem__")(i);
-    auto orientation_constraint_cpp = OrientationConstraintToCpp(orientation_constraint);
+    auto orientation_constraint_cpp =
+        OrientationConstraintToCpp(py::reinterpret_borrow<py::object>(orientation_constraint));
     constraints_cpp.orientation_constraints.push_back(orientation_constraint_cpp);
   }
 
   // iterate through python list creating C++ vector of visibility constraints
-  int num_visibility_constraints = constraints.attr("visibility_constraints").attr("__len__")().cast<int>();
-  for (int i = 0; i < num_visibility_constraints; i++)
+  for (const auto& visibility_constraint : constraints.attr("visibility_constraints"))
   {
-    py::object visibility_constraint = constraints.attr("visibility_constraints").attr("__getitem__")(i);
-    auto visibility_constraint_cpp = VisibilityConstraintToCpp(visibility_constraint);
+    auto visibility_constraint_cpp =
+        VisibilityConstraintToCpp(py::reinterpret_borrow<py::object>(visibility_constraint));
     constraints_cpp.visibility_constraints.push_back(visibility_constraint_cpp);
   }
 


### PR DESCRIPTION
### Description
Moveit Python: The PR replaced traditional for loops with range-based for loops #1930
The range based for loops were of type `py::handle` so there is conversion to `py::object` through `py::reinterpret_borrow<py::object> ` instead of `py::reinterpret_steal<py::object> ` assuming reference borrow is needed instead of ownership transfer.

### Suggestion
All the methods such as [MeshToCpp](https://github.com/peterdavidfagan/moveit2/blob/2e406103c24f58003445a3693bdb79e136e1cbcc/moveit_py/src/moveit/moveit_py_utils/src/copy_ros_msg.cpp#L145) in [copy_ros_msg.cpp](https://github.com/peterdavidfagan/moveit2/blob/2e406103c24f58003445a3693bdb79e136e1cbcc/moveit_py/src/moveit/moveit_py_utils/src/copy_ros_msg.cpp) are defined to take `py::object` as argument which can be modified to `py::handle` as pyhandle will be able to accept both py::object and `py::none` in case python object is null. However this would not be the case if we need to own a python object or perform type checking or need to modify reference count which I don't think is the case with the code here. Please correct me as I might be wrong.

### NOTE:
Also, if we are to use `py::handle` then the range-based for-loops won't have to convert the elements to `py::object` before passing to methods. The code build successfully for the current changes as well as for the suggested changes through [moveit/moveit2:humble-ci-testing](https://hub.docker.com/layers/moveit/moveit2/humble-ci-testing/images/sha256-695094815bd92f06e7c2c41f7d404e710e0b3159c6031e9551347cebf0478b1a?context=explore) docker image.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
